### PR TITLE
0/1 Knapsack

### DIFF
--- a/0-1knapsack.c
+++ b/0-1knapsack.c
@@ -1,0 +1,34 @@
+#include<string.h>
+#include<stdlib.h>
+#include<stdio.h>
+#include<sys/param.h>
+int main(int argc,char** argv){
+	unsigned int space=atoi(argv[1])+1;
+	unsigned int N=1,l;
+	l=strlen(argv[2]);
+	for(unsigned int i=0;i<l;i++)
+		if(argv[2][i]==',')N++;
+	int weight[N],profit[N];
+	for(unsigned int i=0;i<N;i++){
+		weight[i]=atoi(strtok_r(argv[2],",",&argv[2]));
+		profit[i]=atoi(strtok_r(argv[3],",",&argv[3]));
+	}
+	int table[++N][space];
+	for(unsigned int i=0;i<space;i++)table[0][i]=0;
+	for(unsigned int i=1;i<N;i++){
+		table[i][0]=0;
+		for(unsigned int j=1;j<space;j++)
+			if(j<weight[i-1])
+				table[i][j]=table[i-1][j];
+			else
+				table[i][j]=MAX(table[i-1][j-weight[i-1]]+profit[i-1],table[i-1][j]);
+	}
+	printf("Total profit: %d\nBlocks included:\n",table[N-1][space-1]);
+	unsigned int j=space-1;
+	for(unsigned int i=N-1;j>0;i--)
+		if(table[i][j]!=table[i-1][j]){
+			printf("%d\n",i);
+			j-=weight[i-1];
+		}
+	return 0;
+}


### PR DESCRIPTION
## Tests
### debug.gdb
```
break 11
break 16
break 25
run 5 1,2,3 10,20,40
print N
continue
print profit
print weight
continue
print table
continue
quit
```
### ```gdb a.out -x debug.gdb```
```
Reading symbols from ./a.out...
Breakpoint 1 at 0x1216: file 0-1knapsack.c, line 11.
Breakpoint 2 at 0x133d: file 0-1knapsack.c, line 16.
Breakpoint 3 at 0x155d: file 0-1knapsack.c, line 26.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".

Breakpoint 1, main (argc=4, argv=0x7fffffffe5e8) at 0-1knapsack.c:11
11              int weight[N],profit[N];
$1 = 3

Breakpoint 2, main (argc=4, argv=0x7fffffffe5e8) at 0-1knapsack.c:16
16              int table[++N][space];
$2 = {10, 20, 40}
$3 = {1, 2, 3}

Breakpoint 3, main (argc=4, argv=0x7fffffffe5e8) at 0-1knapsack.c:26
26              printf("Total profit: %d\nBlocks included:\n",table[N-1][sp
ace-1]);
$4 = {{0, 0, 0, 0, 0, 0}, {0, 10, 10, 10, 10, 10}, {0, 10, 20, 30, 30, 
    30}, {0, 10, 20, 40, 50, 60}}
Total profit: 60
Blocks included:
3
2
[Inferior 1 (process 36646) exited normally]
```